### PR TITLE
Fix travis ci status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ Deploy both the stand-alone archive and a jar with just the GeoScript JS modules
 
     mvn deploy
 
-[![Current Status](https://secure.travis-ci.org/tschaub/geoscript-js.png?branch=master)](https://travis-ci.org/tschaub/geoscript-js)
+[![Current Status](https://secure.travis-ci.org/geoscript/geoscript-js.png?branch=master)](https://travis-ci.org/geoscript/geoscript-js)


### PR DESCRIPTION
Moving to the geoscript github group broke the travis ci indicator icon.  This fixes it.
