### PR TITLE
Add curved geometry support: CircularStrings and CompoundCurves

### DIFF
--- a/doc/api/geom.rst
+++ b/doc/api/geom.rst
@@ -24,6 +24,8 @@ Constructors
     geom/multilinestring
     geom/multipolygon
     geom/bounds
+    geom/circularstring
+    geom/compoundcurve
 
 
 Module Data

--- a/doc/api/geom/circularstring.rst
+++ b/doc/api/geom/circularstring.rst
@@ -1,0 +1,57 @@
+:class:`geom.CircularString`
+========================
+
+.. class:: geom.CircularString(coords)
+
+    :arg Array coords: Coordinates array.
+
+    Create a new circularstring.
+
+
+Example Use
+-----------
+
+Sample code to new circularstring:
+
+.. code-block:: javascript
+
+    >> var CircularString = require("geoscript/geom").CircularString;
+    >> var cs = new CircularString([[6.12, 10.0], [7.07, 7.07], [10.0, 0.0]]);
+    >> cs.controlPoints.length
+    3
+    >> cs.linear.getGeometryType()
+    LineString
+    >> cs.curvedWkt
+    CIRCULARSTRING(6.12 10.0, 7.07 7.07, 10.0 0.0)
+
+
+Properties
+----------
+
+In addition to the properties common to :class:`geom.LineString` subclasses,
+circularstring geometries have the properties documented below.
+
+
+.. attribute:: CircularString.curvedWkt
+
+    :class:`String`
+    The curved WKT as a string.
+
+.. attribute:: CircularString.controlPoints
+
+    ``Array``
+    An array of the original control Points.
+
+
+.. attribute:: CircularString.linear
+
+    :class:`geom.LineString`
+    A linearized LineString.
+
+
+
+Methods
+-------
+
+CircularString geometries have the methods common to :class:`geom.LineString`
+subclasses.

--- a/doc/api/geom/compoundcurve.rst
+++ b/doc/api/geom/compoundcurve.rst
@@ -1,0 +1,56 @@
+:class:`geom.CompoundCurve`
+===========================
+
+.. class:: geom.CompoundCurve(lineStrings)
+
+    :arg Array lineStrings: An array of LineStrings or CircularStrings.
+
+    Create a new CompoundCurve.
+
+
+Example Use
+-----------
+
+Sample code to new compoundcurve:
+
+.. code-block:: javascript
+
+    >> var GEOM = require("geoscript/geom");
+    >> var cs = new GEOM.CircularString([[10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]]);
+    >> var line = new GEOM.LineString([[-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [5.0, 5.0]])
+    >> var cc = new GEOM.CompoundCurve([cs, line]);
+    >> cc.components.length
+    2
+    >> cc.linear.getGeometryType()
+    LineString
+    >> cc.curvedWkt
+    COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))
+
+
+Properties
+----------
+
+In addition to the properties common to all :class:`geom.LineString` subclasses,
+compoundcurve geometries have the properties documented below.
+
+
+.. attribute:: CompoundCurve.components
+
+    :class:`geom.LineString`
+    The original LineString or CircularStrings.
+
+.. attribute:: CircularString.curvedWkt
+
+    :class:`String`
+    The curved WKT as a string.
+
+.. attribute:: CircularString.linear
+
+    :class:`geom.LineString`
+    A linearized LineString.
+
+Methods
+-------
+
+CompoundCurve geometries have the methods common to all :class:`geom.LineString`
+subclasses.

--- a/src/main/java/org/geoscript/js/geom/CircularString.java
+++ b/src/main/java/org/geoscript/js/geom/CircularString.java
@@ -1,0 +1,139 @@
+package org.geoscript.js.geom;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import org.geotools.geometry.jts.CurvedGeometryFactory;
+import org.mozilla.javascript.*;
+import org.mozilla.javascript.annotations.JSConstructor;
+import org.mozilla.javascript.annotations.JSGetter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CircularString extends LineString implements Wrapper {
+
+    /** serialVersionUID */
+    private static final long serialVersionUID = -5048539260091857410L;
+
+    /**
+     * Prototype constructor.
+     * @return
+     */
+    public CircularString() {
+    }
+
+    /**
+     * Constructor for config object.
+     * @param config
+     */
+    public CircularString(NativeObject config) {
+        NativeArray array = (NativeArray) config.get("coordinates", config);
+        double tolerance = config.has("tolerance", config) ? (Double) config.get("tolerance", config) : Double.MAX_VALUE;
+        Coordinate[] coords = arrayToCoords(array);
+        setGeometry(createCircularString(coords, tolerance));
+    }
+
+    /**
+     * Constructor for config object (without new keyword).
+     * @param scope
+     * @param config
+     */
+    public CircularString(Scriptable scope, NativeObject config) {
+        this(config);
+        this.setParentScope(scope);
+        this.setPrototype(Module.getClassPrototype(CircularString.class));
+    }
+
+    /**
+     * Constructor from JTS geometry.
+     * @param geometry
+     */
+    public CircularString(Scriptable scope, org.geotools.geometry.jts.CircularString geometry) {
+        this.setParentScope(scope);
+        this.setPrototype(Module.getClassPrototype(CircularString.class));
+        setGeometry(geometry);
+    }
+
+    /**
+     * JavaScript constructor.
+     * @param cx
+     * @param args
+     * @param ctorObj
+     * @param inNewExpr
+     * @return
+     */
+    @JSConstructor
+    public static Object constructor(Context cx, Object[] args, Function ctorObj, boolean inNewExpr) {
+        if (args.length != 1) {
+            throw ScriptRuntime.constructError("Error", "CircularString constructor takes a single argument");
+        }
+        NativeObject config = prepConfig(cx, (Scriptable) args[0]);
+        CircularString line = null;
+        if (inNewExpr) {
+            line = new CircularString(config);
+        } else {
+            line = new CircularString(config.getParentScope(), config);
+        }
+        return line;
+    }
+
+    /**
+     * Create a CircularString from an array of Coordinates and a tolerance used to linearize the curve.
+     * @param coords The Array of Coordinates
+     * @param tolerance The tolerance used to linearize the curve
+     * @return A CircularString
+     */
+    private com.vividsolutions.jts.geom.Geometry createCircularString(Coordinate[] coords, double tolerance) {
+        CurvedGeometryFactory factory = new CurvedGeometryFactory(tolerance);
+        double[] values = new double[coords.length * 2];
+        for(int i = 0; i < coords.length; i++) {
+            int c = i * 2;
+            values[c] = coords[i].x;
+            values[c + 1] = coords[i].y;
+        }
+        return new org.geotools.geometry.jts.CircularString(values, factory, tolerance);
+    }
+
+    /**
+     * Get the curved WKT
+     * @return The curved WKT
+     */
+    @JSGetter
+    public String getCurvedWkt() {
+        return ((org.geotools.geometry.jts.CircularString)getGeometry()).toCurvedText();
+    }
+
+    /**
+     * Get the original control Points (not the linearized Points)
+     * @return The original control Points
+     */
+    @JSGetter
+    public NativeArray getControlPoints() {
+        Context cx = getCurrentContext();
+        List<Point> points = new ArrayList<>();
+        org.geotools.geometry.jts.CircularString cs = (org.geotools.geometry.jts.CircularString)getGeometry();
+        double[] cp = cs.getControlPoints();
+        for(int i=0; i<cp.length; i=i+2) {
+            Point pt = new Point(getParentScope(), factory.createPoint(new Coordinate(cp[i], cp[i+1])));
+            points.add(pt);
+        }
+        return (NativeArray) cx.newArray(getParentScope(), points.toArray());
+    }
+
+    /**
+     * Get the linearized Geometry
+     * @return The linearized Geometry
+     */
+    @JSGetter
+    public Geometry getLinear() {
+        org.geotools.geometry.jts.CircularString cs = (org.geotools.geometry.jts.CircularString)getGeometry();
+        return (Geometry) GeometryWrapper.wrap(getParentScope(), cs.linearize());
+    }
+
+    /**
+     * Returns underlying JTS geometry.
+     */
+    public org.geotools.geometry.jts.CircularString unwrap() {
+        return (org.geotools.geometry.jts.CircularString) getGeometry();
+    }
+
+}

--- a/src/main/java/org/geoscript/js/geom/CompoundCurve.java
+++ b/src/main/java/org/geoscript/js/geom/CompoundCurve.java
@@ -1,0 +1,188 @@
+package org.geoscript.js.geom;
+
+import org.geoscript.js.io.JSON;
+import org.geotools.geometry.jts.CurvedGeometryFactory;
+import org.mozilla.javascript.*;
+import org.mozilla.javascript.annotations.JSConstructor;
+import org.mozilla.javascript.annotations.JSGetter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompoundCurve extends LineString implements Wrapper {
+
+    /** serialVersionUID */
+    private static final long serialVersionUID = -5048539260091857410L;
+
+    /**
+     * Prototype constructor.
+     * @return
+     */
+    public CompoundCurve() {
+    }
+
+    /**
+     * Constructor for coordinate array.
+     * @param array
+     */
+    public CompoundCurve(NativeArray array) {
+        double tolerance = Double.MAX_VALUE;
+        setGeometry(curveFromArray(array, tolerance));
+    }
+
+    /**
+     * Constructor from array (without new keyword).
+     * @param scope
+     * @param array
+     */
+    public CompoundCurve(Scriptable scope, NativeArray array) {
+        this(array);
+        this.setParentScope(scope);
+        this.setPrototype(Module.getClassPrototype(CompoundCurve.class));
+    }
+
+    /**
+     * Constructor from config object.
+     * @param config
+     */
+    public CompoundCurve(NativeObject config) {
+        double tolerance = config.has("tolerance", config)
+                ? Double.valueOf(config.get("tolerance", config).toString()) : Double.MAX_VALUE;
+        NativeArray array = (NativeArray) getRequiredMember(config, "geometries", NativeArray.class, "Array");
+        setGeometry(curveFromArray(array, tolerance));
+    }
+
+    /**
+     * Constructor from config object (without new keyword).
+     * @param scope
+     * @param config
+     */
+    public CompoundCurve(Scriptable scope, NativeObject config) {
+        this(config);
+        this.setParentScope(scope);
+        this.setPrototype(Module.getClassPrototype(CompoundCurve.class));
+    }
+
+    /**
+     * Constructor from JTS geometry.
+     * @param geometry
+     */
+    public CompoundCurve(Scriptable scope, org.geotools.geometry.jts.CompoundCurve geometry) {
+        this.setParentScope(scope);
+        this.setPrototype(Module.getClassPrototype(CompoundCurve.class));
+        setGeometry(geometry);
+    }
+
+    /**
+     * Create a JTS geometry collection from a JS array
+     * @param array
+     * @return
+     */
+    private org.geotools.geometry.jts.CompoundCurve curveFromArray(NativeArray array, double tolerance) {
+        Scriptable scope = array.getParentScope();
+        Context context = getCurrentContext();
+        int numComponents = array.size();
+        List<com.vividsolutions.jts.geom.LineString> lines =  new ArrayList<com.vividsolutions.jts.geom.LineString>();
+        for (int i=0; i<numComponents; ++i) {
+            Object obj = array.get(i);
+            if (obj instanceof com.vividsolutions.jts.geom.LineString) {
+                lines.add((com.vividsolutions.jts.geom.LineString) obj);
+            } else if (obj instanceof NativeObject) {
+                Geometry geomObj = (Geometry) JSON.readObj((NativeObject) obj);
+                lines.add((com.vividsolutions.jts.geom.LineString) geomObj.unwrap());
+            } else if (obj instanceof LineString) {
+                lines.add((com.vividsolutions.jts.geom.LineString) ((Geometry)obj).unwrap());
+            }
+        }
+        CurvedGeometryFactory factory = new CurvedGeometryFactory(tolerance);
+        return new org.geotools.geometry.jts.CompoundCurve(lines, factory, tolerance);
+    }
+
+    /**
+     * JavaScript constructor.
+     * @param cx
+     * @param args
+     * @param ctorObj
+     * @param inNewExpr
+     * @return
+     */
+    @JSConstructor
+    public static Object constructor(Context cx, Object[] args, Function ctorObj, boolean inNewExpr) {
+        if (args.length != 1) {
+            throw ScriptRuntime.constructError("Error", "CompoundCurve constructor takes a single argument");
+        }
+        NativeObject config = prepConfig(cx, (Scriptable) args[0]);
+        CompoundCurve cc = null;
+        if (inNewExpr) {
+            cc = new CompoundCurve(config);
+        } else {
+            cc = new CompoundCurve(config.getParentScope(), config);
+        }
+        return cc;
+    }
+
+    /**
+     * Convert the provided object into an acceptable geometry config object.
+     * @param context
+     * @param configObj
+     * @return
+     */
+    protected static NativeObject prepConfig(Context context, Scriptable configObj) {
+        Scriptable scope = configObj.getParentScope();
+        NativeObject config = null;
+        if (configObj instanceof NativeObject) {
+            getRequiredMember(configObj, "geometries", NativeArray.class, "Array");
+            config = (NativeObject) configObj;
+        } else if (configObj instanceof NativeArray) {
+            NativeArray array = (NativeArray) configObj;
+            config = (NativeObject) context.newObject(scope);
+            config.put("geometries", config, array);
+        } else {
+            throw ScriptRuntime.constructError("Error",
+                    "CompoundCurve config must be an array of linestring or circularstrings");
+        }
+        return config;
+    }
+
+    /**
+     * Get the curved WKT
+     * @return The curved WKT
+     */
+    @JSGetter
+    public String getCurvedWkt() {
+        return ((org.geotools.geometry.jts.CompoundCurve) getGeometry()).toCurvedText();
+    }
+
+    /**
+     * Get the original LineStrings or CircularStrings (not linearized)
+     * @return The original LineStrings or CircularStrings
+     */
+    @JSGetter
+    public NativeArray getComponents() {
+        Context cx = getCurrentContext();
+        org.geotools.geometry.jts.CompoundCurve cs = (org.geotools.geometry.jts.CompoundCurve)getGeometry();
+        List<LineString> lineStrings = new ArrayList<LineString>();
+        List<com.vividsolutions.jts.geom.LineString> lines = cs.getComponents();
+        for (com.vividsolutions.jts.geom.LineString line : lines) {
+            lineStrings.add((LineString)GeometryWrapper.wrap(getParentScope(), line));
+        }
+        return (NativeArray) cx.newArray(getParentScope(), lineStrings.toArray());
+    }
+
+    /**
+     * Get the linearized Geometry
+     * @return The linearized Geometry
+     */
+    @JSGetter
+    public Geometry getLinear() {
+        org.geotools.geometry.jts.CompoundCurve cs = (org.geotools.geometry.jts.CompoundCurve)getGeometry();
+        return (Geometry) GeometryWrapper.wrap(getParentScope(), cs.linearize());
+    }
+
+    /**
+     * Returns underlying JTS geometry.
+     */
+    public org.geotools.geometry.jts.CompoundCurve unwrap() {
+        return (org.geotools.geometry.jts.CompoundCurve) getGeometry();
+    }
+}

--- a/src/main/java/org/geoscript/js/geom/GeometryWrapper.java
+++ b/src/main/java/org/geoscript/js/geom/GeometryWrapper.java
@@ -10,6 +10,10 @@ public class GeometryWrapper {
         try {
             if (geometry instanceof com.vividsolutions.jts.geom.Point) {
                 wrapped = new Point(scope, (com.vividsolutions.jts.geom.Point) geometry);
+            } else if (geometry instanceof org.geotools.geometry.jts.CompoundCurve) {
+                wrapped = new CompoundCurve(scope, (org.geotools.geometry.jts.CompoundCurve) geometry);
+            } else if (geometry instanceof org.geotools.geometry.jts.CircularString) {
+                wrapped = new CircularString(scope, (org.geotools.geometry.jts.CircularString) geometry);
             } else if (geometry instanceof com.vividsolutions.jts.geom.LineString) {
                 wrapped = new LineString(scope, (com.vividsolutions.jts.geom.LineString) geometry);
             } else if (geometry instanceof com.vividsolutions.jts.geom.Polygon) {

--- a/src/main/java/org/geoscript/js/geom/Module.java
+++ b/src/main/java/org/geoscript/js/geom/Module.java
@@ -30,7 +30,8 @@ public class Module {
         List<Class<? extends GeoObject>> classes = Arrays.asList(
                 Geometry.class, Point.class, LineString.class,
                 Polygon.class, GeometryCollection.class, MultiPoint.class,
-                MultiLineString.class, MultiPolygon.class, Bounds.class);
+                MultiLineString.class, MultiPolygon.class, Bounds.class,
+                CircularString.class, CompoundCurve.class);
         
         prototypes = new HashMap<String, Scriptable>();
         for (Class<? extends GeoObject> cls : classes) {

--- a/src/main/java/org/geoscript/js/io/WKT.java
+++ b/src/main/java/org/geoscript/js/io/WKT.java
@@ -11,11 +11,12 @@ import org.mozilla.javascript.ScriptableObject;
 
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
+import org.geotools.geometry.jts.WKTReader2;
 import com.vividsolutions.jts.io.WKTWriter;
 
 public class WKT {
 
-    static WKTReader wktReader = new WKTReader();
+    static WKTReader wktReader = new WKTReader2();
     static WKTWriter wktWriter = new WKTWriter();
 
     /**

--- a/src/main/resources/org/geoscript/js/lib/geoscript/geom.js
+++ b/src/main/resources/org/geoscript/js/lib/geoscript/geom.js
@@ -165,6 +165,37 @@ registry.register(new Factory(exports.MultiPolygon, {
   }
 }));
 
+/** api: classes[] = circularstring */
+exports.CircularString = this["org.geoscript.js.geom.CircularString"];
+
+//register a circularstring factory for the module
+registry.register(new Factory(exports.CircularString, {
+  handles: function(config) {
+    config = prepConfig(config);
+    var capable = false;
+    if (config.coordinates && UTIL.isArray(config.coordinates)) {
+      for (var i=0, ii=config.coordinates.length; i<ii; ++i) {
+        var p = config.coordinates[i];
+        if (UTIL.isArray(p)) {
+          var len = p.length;
+          if (len === 2 || len === 3) {
+            capable = true;
+            for (var j=0; j<len; ++j) {
+              capable = capable && (typeof p[j] === "number");
+            }
+          }
+        }
+      }
+    }
+    return capable;
+  }
+}));
+
+/** api: classes[] = compoundcurve */
+exports.CompoundCurve = this["org.geoscript.js.geom.CompoundCurve"];
+
+//register a compoundcurve factory for the module
+registry.register(new Factory(exports.CompoundCurve));
 
 /** api: classes[] = bounds */
 exports.Bounds = this["org.geoscript.js.geom.Bounds"];

--- a/src/test/resources/org/geoscript/js/tests/geoscript/geom/test_circularstring.js
+++ b/src/test/resources/org/geoscript/js/tests/geoscript/geom/test_circularstring.js
@@ -1,0 +1,41 @@
+var ASSERT = require("assert");
+var GEOM = require("geoscript/geom");
+var PROJ = require("geoscript/proj");
+var WKT = require("geoscript/io/wkt");
+
+exports["test: constructor"] = function() {
+
+    var checkPoint = function(i, pt, x, y) {
+        ASSERT.ok(pt instanceof GEOM.Point, "cr control point #" + i + " is a point");
+        ASSERT.strictEqual(pt.x, x, "cr control point #" + i + " x is " + x);
+        ASSERT.strictEqual(pt.y, y, "cr control point #" + i + " y is " + y);
+    };
+
+    var cs = new GEOM.CircularString([[6.12, 10.0], [7.07, 7.07], [10.0, 0.0]]);
+
+    ASSERT.ok(cs instanceof GEOM.Geometry, "cs is a geometry");
+    ASSERT.ok(cs instanceof GEOM.CircularString, "cs is a circularstring");
+    ASSERT.strictEqual(cs.controlPoints.length, 3, "cs has three control points");
+    checkPoint(0, cs.controlPoints[0], 6.12, 10.0);
+    checkPoint(1, cs.controlPoints[1], 7.07, 7.07);
+    checkPoint(2, cs.controlPoints[2], 10.0, 0.0);
+    ASSERT.ok(cs.linear instanceof GEOM.LineString,"cs linear is a linestring");
+    ASSERT.strictEqual("CIRCULARSTRING(6.12 10.0, 7.07 7.07, 10.0 0.0)", cs.curvedWkt, "cs curved wkt is CIRCULARSTRING(6.12 10.0, 7.07 7.07, 10.0 0.0)");
+    var csFromWkt = WKT.read("CIRCULARSTRING(6.12 10.0, 7.07 7.07, 10.0 0.0)");
+    ASSERT.deepEqual(cs, csFromWkt);
+
+    var p0 = new GEOM.Point([6.12, 10.0]);
+    var p1 = new GEOM.Point([7.07, 7.07]);
+    var p2 = new GEOM.Point([10.0, 0.0]);
+    var cs2 = new GEOM.CircularString([p0, p1, p2]);
+
+    ASSERT.ok(cs2 instanceof GEOM.Geometry, "cs2 is a geometry");
+    ASSERT.ok(cs2 instanceof GEOM.CircularString, "cs2 is a circularstring");
+    ASSERT.strictEqual(cs2.controlPoints.length, 3, "cs2 has three control points");
+    checkPoint(0, cs.controlPoints[0], 6.12, 10.0);
+    checkPoint(1, cs.controlPoints[1], 7.07, 7.07);
+    checkPoint(2, cs.controlPoints[2], 10.0, 0.0);
+    ASSERT.ok(cs2.linear instanceof GEOM.LineString,"cs2 linear is a linestring");
+    ASSERT.strictEqual("CIRCULARSTRING(6.12 10.0, 7.07 7.07, 10.0 0.0)", cs2.curvedWkt, "cs2 curved wkt is CIRCULARSTRING(6.12 10.0, 7.07 7.07, 10.0 0.0)");
+
+};

--- a/src/test/resources/org/geoscript/js/tests/geoscript/geom/test_compoundcurve.js
+++ b/src/test/resources/org/geoscript/js/tests/geoscript/geom/test_compoundcurve.js
@@ -1,0 +1,59 @@
+var ASSERT = require("assert");
+var GEOM = require("geoscript/geom");
+var PROJ = require("geoscript/proj");
+var WKT = require("geoscript/io/wkt");
+
+exports["test: constructor"] = function() {
+
+    var checkPoint = function(pt, x, y) {
+        ASSERT.ok(pt instanceof GEOM.Point, "point is a point");
+        ASSERT.strictEqual(pt.x, x, "point x is " + x);
+        ASSERT.strictEqual(pt.y, y, "point y is " + y);
+    };
+
+    var cc = new GEOM.CompoundCurve([
+        new GEOM.CircularString([[10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]]),
+        new GEOM.LineString([[-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [5.0, 5.0]])
+    ]);
+
+    ASSERT.ok(cc instanceof GEOM.Geometry, "cc is a geometry");
+    ASSERT.ok(cc instanceof GEOM.CompoundCurve, "cc is a compoundcurve");
+    ASSERT.strictEqual(cc.components.length, 2, "cc has two components");
+    ASSERT.ok(cc.components[0] instanceof GEOM.CircularString, "cc component 1 is a circularstring");
+    ASSERT.ok(cc.components[1] instanceof GEOM.LineString, "cc component 2 is a linestring");
+    var cs = cc.components[0];
+    checkPoint(cs.controlPoints[0], 10.0, 10.0);
+    checkPoint(cs.controlPoints[1], 0.0, 20.0);
+    checkPoint(cs.controlPoints[2], -10.0, 10.0);
+    var ls = cc.components[1];
+    ASSERT.strictEqual(ls.coordinates.length, 4, "line has four coordinates");
+    ASSERT.deepEqual([[-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [5.0, 5.0]], ls.coordinates, "line coordinates match");
+    ASSERT.ok(cc.linear instanceof GEOM.LineString,"cc linear is a linestring");
+    ASSERT.strictEqual("COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))", cc.curvedWkt, "cs curved wkt");
+    var ccFromWkt = WKT.read("COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))");
+    ASSERT.deepEqual(cc, ccFromWkt);
+
+    cc = new GEOM.CompoundCurve({
+        geometries: [
+            new GEOM.CircularString([[10.0, 10.0], [0.0, 20.0], [-10.0, 10.0]]),
+            new GEOM.LineString([[-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [5.0, 5.0]])
+        ],
+        tolerance: 25
+    });
+
+    ASSERT.ok(cc instanceof GEOM.Geometry, "cc is a geometry");
+    ASSERT.ok(cc instanceof GEOM.CompoundCurve, "cc is a compoundcurve");
+    ASSERT.strictEqual(cc.components.length, 2, "cc has two components");
+    ASSERT.ok(cc.components[0] instanceof GEOM.CircularString, "cc component 1 is a circularstring");
+    ASSERT.ok(cc.components[1] instanceof GEOM.LineString, "cc component 2 is a linestring");
+    var cs = cc.components[0];
+    checkPoint(cs.controlPoints[0], 10.0, 10.0);
+    checkPoint(cs.controlPoints[1], 0.0, 20.0);
+    checkPoint(cs.controlPoints[2], -10.0, 10.0);
+    var ls = cc.components[1];
+    ASSERT.strictEqual(ls.coordinates.length, 4, "line has four coordinates");
+    ASSERT.deepEqual([[-10.0, 10.0], [-10.0, 0.0], [10.0, 0.0], [5.0, 5.0]], ls.coordinates, "line coordinates match");
+    ASSERT.ok(cc.linear instanceof GEOM.LineString,"cc linear is a linestring");
+    ASSERT.strictEqual("COMPOUNDCURVE(CIRCULARSTRING(10.0 10.0, 0.0 20.0, -10.0 10.0), (-10.0 10.0, -10.0 0.0, 10.0 0.0, 5.0 5.0))", cc.curvedWkt, "cs curved wkt");
+
+};

--- a/src/test/resources/org/geoscript/js/tests/geoscript/test_geom.js
+++ b/src/test/resources/org/geoscript/js/tests/geoscript/test_geom.js
@@ -163,6 +163,8 @@ exports["test: Polygon"] = require("./geom/test_polygon");
 exports["test: Collection"] = require("./geom/test_collection");
 exports["test: MultiLineString"] = require("./geom/test_multilinestring");
 exports["test: Bounds"] = require("./geom/test_bounds");
+exports["test: CircularString"] = require("./geom/test_circularstring");
+exports["test: CompoundCurve"] = require("./geom/test_compoundcurve");
 
 if (require.main == module.id) {
     system.exit(require("test").run(exports));


### PR DESCRIPTION
GeoTools 12 recently added limited support for curved geometry.  This pull request adds GeoScript wrappers for CircularStrings and CompoundCurves.
