### PR TITLE
Add a Geometry.densify(tolerance) method

### DIFF
--- a/doc/api/geom/geometry.rst
+++ b/doc/api/geom/geometry.rst
@@ -141,6 +141,16 @@ Common Geometry Methods
     
     Tests if this geometry crosses the other geometry.
 
+.. function:: Geometry.densify
+
+    :arg tolerance: ``Number`` The distance tolerance for the densification.
+        All line segments in the densified geometry will be no longer than the distance tolereance.
+        The tolerance value must be non-negative.
+    :returns: :class:`geom.Geometry`
+
+     Densifies a geometry object adding vertices along the line segments of the
+     geometry.
+
 .. function:: Geometry.difference
 
     :arg other: :class:`geom.Geometry`

--- a/src/main/java/org/geoscript/js/geom/Geometry.java
+++ b/src/main/java/org/geoscript/js/geom/Geometry.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 
+import com.vividsolutions.jts.densify.Densifier;
 import org.geoscript.js.GeoObject;
 import org.geoscript.js.proj.Projection;
 import org.geotools.geometry.jts.GeometryCoordinateSequenceTransformer;
@@ -291,7 +292,15 @@ public class Geometry extends GeoObject implements Wrapper {
         ((Geometry) simplified).projection = projection;
         return simplified;
     }
-    
+
+    @JSFunction
+    public ScriptableObject densify(double tolerance) {
+        com.vividsolutions.jts.geom.Geometry geom = Densifier.densify(geometry, tolerance);
+        ScriptableObject densified = GeometryWrapper.wrap(getParentScope(), geom);
+        ((Geometry) densified).projection = projection;
+        return densified;
+    }
+
     @JSFunction
     public String getGeometryType() {
         return geometry.getGeometryType();

--- a/src/test/resources/org/geoscript/js/tests/geoscript/geom/test_multilinestring.js
+++ b/src/test/resources/org/geoscript/js/tests/geoscript/geom/test_multilinestring.js
@@ -47,6 +47,17 @@ exports["test: simplify"] = function() {
 
 };
 
+exports["test: densify"] = function() {
+
+    var g = new GEOM.MultiLineString([[[1, 1], [2, 2], [3, 1], [4, 2]], [[-1, -1], [-2, -2], [-3, -1], [-4, -2]]]);
+    g.projection = "epsg:4326";
+    var g2 = g.densify(0.5);
+
+    ASSERT.ok(g2 instanceof GEOM.MultiLineString, "correct type");
+    ASSERT.ok(g2.coordinates[0].length > g.coordinates[0].length, "densified line has more coordinates");
+    ASSERT.ok(g.projection.equals(g.projection), "same projection");
+};
+
 
 exports["test: bounds"] = function() {
 


### PR DESCRIPTION
Hi Tim!

Justin added a Geometry densify method to the Python bindings, so I thought I would add it to JavaScript.

Thanks!
Jared