### PR TITLE
Restore repo.boundlessgeo.com

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,13 +267,13 @@
         <repository>
             <id>boundless</id>
             <name>Boundless Release Repository</name>
-            <url>https://boundless.artifactoryonline.com/boundless/release/</url>
+            <url>https://repo.boundlessgeo.com/release/</url>
             <uniqueVersion>false</uniqueVersion>
         </repository>
         <snapshotRepository>
             <id>boundless</id>
             <name>Boundless Snapshot Repository</name>
-            <url>https://boundless.artifactoryonline.com/boundless/snapshot/</url>
+            <url>https://repo.boundlessgeo.com/snapshot/</url>
             <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
     </distributionManagement>


### PR DESCRIPTION
The temporary use of the artifactoryonline URL is complete, repo.boundlessgeo.com now points to the same cloud instance.